### PR TITLE
Missing parentheses fix

### DIFF
--- a/src/views/start/index.jsx
+++ b/src/views/start/index.jsx
@@ -54,7 +54,7 @@ export default class Start extends Component {
       ele.classList.add('loadingscreen-active');
       ele.classList.remove('loadingscreen-passive');
 
-      this.setState({fileStats:{}}
+      this.setState({fileStats:{}})
 
       log(givenpath, this.logDoneCB, this.logProgressCB, queryParameter);
     }


### PR DESCRIPTION
There was a missing parentheses inside  src/views/start/index.jsx. 